### PR TITLE
Remove # parts intermediate layer, use JSON directly

### DIFF
--- a/custom_components/bemfa_cloud/const.py
+++ b/custom_components/bemfa_cloud/const.py
@@ -85,8 +85,5 @@ CHANGE_TOPIC_ROOM_URL: Final = "http://apis.bemfa.com/vb/api/v1/changeTopicRoom"
 MODIFY_TOPIC_NAME_URL: Final = "https://apis.bemfa.com/va/modifyName"
 
 TOPIC_PREFIX: Final = "ha"
-MSG_SEPARATOR: Final = "#"
-MSG_ON: Final = "on"
-MSG_OFF: Final = "off"
 MSG_PAUSE: Final = "pause"
 MSG_SPEED_COUNT: Final = 4

--- a/custom_components/bemfa_cloud/manifest.json
+++ b/custom_components/bemfa_cloud/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/bemfa/bemfa_cloud_ha/issues",
   "requirements": [],
-  "version": "0.1.12"
+  "version": "0.1.13"
 }

--- a/custom_components/bemfa_cloud/sync.py
+++ b/custom_components/bemfa_cloud/sync.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import json
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Callable
+from collections.abc import Mapping
 import hashlib
 from typing import Any
 import voluptuous as vol
@@ -15,9 +15,6 @@ from homeassistant.util.decorator import Registry
 from homeassistant.util.read_only_dict import ReadOnlyDict
 
 from .const import (
-    MSG_OFF,
-    MSG_ON,
-    MSG_SEPARATOR,
     OPTIONS_FAN_SPEED_0_VALUE,
     OPTIONS_FAN_SPEED_1_VALUE,
     OPTIONS_FAN_SPEED_2_VALUE,
@@ -45,7 +42,7 @@ CLIMATE_SWING_CONFIG_KEYS = [
     OPTIONS_SWING_VERTICAL_VALUE,
     OPTIONS_SWING_BOTH_VALUE,
 ]
-CLIMATE_SWING_VALUES = ["0#0", "1#0", "0#1", "1#1"]
+CLIMATE_SWING_VALUES = [(0, 0), (1, 0), (0, 1), (1, 1)]
 
 
 class Sync(ABC):
@@ -190,78 +187,9 @@ class Sync(ABC):
             return None
         return payload if isinstance(payload, dict) else None
 
+    @abstractmethod
     def _generate_msg_payload(self) -> dict[str, Any]:
         """Generate a Bemfa MI JSON message payload."""
-
-        parts = self._generate_msg_parts()
-
-        # remove useless tail parts
-        while len(parts) > 0 and parts[len(parts) - 1] == "":
-            parts.pop()
-
-        return self._parts_to_payload(parts)
-
-    def _parts_to_payload(self, parts: list[Any]) -> dict[str, Any]:
-        if not parts:
-            return {}
-
-        suffix = self._get_topic_suffix()
-        on = parts[0] == MSG_ON
-        if suffix in (
-            TopicSuffix.OUTLET,
-            TopicSuffix.SWITCH,
-            TopicSuffix.LIGHT,
-            TopicSuffix.FAN,
-            TopicSuffix.TV,
-            TopicSuffix.AIR_PURIFIER,
-        ):
-            payload: dict[str, Any] = {"on": on}
-            if suffix == TopicSuffix.FAN and len(parts) > 1 and parts[1] != "":
-                payload["v"] = _to_int(parts[1])
-            if suffix == TopicSuffix.AIR_PURIFIER and len(parts) > 1 and parts[1] != "":
-                payload["mode"] = parts[1]
-            return payload
-
-        if suffix == TopicSuffix.COVER:
-            payload = {"on": on}
-            if len(parts) > 1 and parts[1] != "":
-                payload["v"] = _to_int(parts[1])
-            return payload
-
-        if suffix in (
-            TopicSuffix.CLIMATE,
-            TopicSuffix.THERMOSTAT,
-            TopicSuffix.WATER_HEATER,
-        ):
-            payload = {"on": on}
-            if len(parts) > 1 and parts[1] != "":
-                if suffix == TopicSuffix.WATER_HEATER:
-                    payload["t"] = _to_int(parts[1])
-                else:
-                    payload["mode"] = _to_int(parts[1])
-            if len(parts) > 2 and parts[2] != "":
-                if suffix == TopicSuffix.WATER_HEATER:
-                    payload["mode"] = parts[2]
-                else:
-                    payload["t"] = _to_int(parts[2])
-            if suffix != TopicSuffix.WATER_HEATER and len(parts) > 3 and parts[3] != "":
-                payload["fan"] = _to_int(parts[3])
-            if suffix in (TopicSuffix.CLIMATE, TopicSuffix.THERMOSTAT):
-                if len(parts) > 4 and parts[4] != "":
-                    swing_parts = str(parts[4]).split(MSG_SEPARATOR)
-                    if len(swing_parts) > 0:
-                        payload["l2r"] = _swing_axis_payload_value(swing_parts[0])
-                    if len(swing_parts) > 1:
-                        payload["u2d"] = _swing_axis_payload_value(swing_parts[1])
-            return payload
-
-        if suffix == TopicSuffix.SENSOR:
-            return {"on": on}
-
-        return {"on": on}
-
-    @abstractmethod
-    def _generate_msg_parts(self) -> list[str]:
         raise NotImplementedError
 
 
@@ -287,66 +215,23 @@ class ControllableSync(Sync):
     def get_watched_entity_ids(self) -> list[str]:
         return [self._entity_id]
 
-    def _generate_msg_parts(self) -> list[str]:
-        state = self._hass.states.get(self._entity_id)
-        if state is None or state.state in UNPUBLISHABLE_STATES:
-            return []
-
-        generators = self._msg_generators()
-        msg = [generators[0](state.state, state.attributes)]
-
-        # if first one is off, the following parts is useless
-        if msg[0] != MSG_OFF:
-            msg += list(
-                map(
-                    lambda f: str(f(state.state, state.attributes)),
-                    generators[1:],
-                )
-            )
-        return msg
-
-    @abstractmethod
-    def _msg_generators(
-        self,
-    ) -> list[Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]]:
-        raise NotImplementedError
-
     def resolve_msg(self, msg: Any):
         """Resolve a message received from Bemfa service."""
         state = self._hass.states.get(self._entity_id)
         if state is None:
             return
 
-        if self._resolve_json_msg(msg, state.attributes):
-            return
+        self._resolve_json_msg(msg, state.attributes)
 
-        msg_list = self._msg_to_parts(msg, state.attributes)
-        if msg_list[0] == MSG_OFF:
-            msg_list = [MSG_OFF]  # discard any data followed by "off"
+    def _resolve_on_off(
+        self, on: bool, attributes: Mapping[str, Any]
+    ) -> tuple[str, str, dict[str, Any]]:
+        """Return (domain, service, data) for a simple on/off command."""
+        from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON
 
-        # generate msg from entity to compare to received msg
-        state_msg_list = MSG_SEPARATOR.join(self._generate_msg_parts()).split(
-            MSG_SEPARATOR
-        )
-
-        for resolver in self._msg_resolvers():
-            start_index = resolver[0]
-            end_index = min(resolver[1], len(msg_list), len(state_msg_list))
-            if msg_list[start_index:end_index] != state_msg_list[start_index:end_index]:
-                (domain, service, data) = resolver[2](
-                    [_coerce_msg_value(msg) for msg in msg_list[start_index:end_index]],
-                    state.attributes,
-                )
-                data.update({ATTR_ENTITY_ID: self._entity_id})
-                self._hass.async_create_task(
-                    self._hass.services.async_call(
-                        domain=domain,
-                        service=service,
-                        service_data=data,
-                        blocking=False,
-                    )
-                )
-                break  # call only one service at most on each msg received
+        domain = self._entity_id.split(".")[0]
+        service = SERVICE_TURN_ON if on else SERVICE_TURN_OFF
+        return (domain, service, {})
 
     def _resolve_json_msg(
         self, msg: Any, attributes: ReadOnlyDict[Mapping[str, Any]]
@@ -364,8 +249,8 @@ class ControllableSync(Sync):
 
         suffix = self._get_topic_suffix()
         if suffix in (TopicSuffix.OUTLET, TopicSuffix.SWITCH, TopicSuffix.TV):
-            parts = [MSG_ON if payload.get("on", True) else MSG_OFF]
-            (domain, service, data) = self._msg_resolvers()[0][2](parts, attributes)
+            on = payload.get("on", True)
+            domain, service, data = self._resolve_on_off(on, attributes)
             self._async_call_service(domain, service, data)
             return True
 
@@ -483,32 +368,28 @@ class ControllableSync(Sync):
                     calls.append((DOMAIN, SERVICE_SET_TEMPERATURE, {ATTR_TEMPERATURE: target_temp}))
 
             if "fan" in payload or "v" in payload:
-                fan_value = payload.get("fan", payload.get("v"))
-                fan_mode = _climate_fan_mode(
-                    _to_int(fan_value),
-                    self._config,
-                    attributes.get(ATTR_FAN_MODES, []),
-                )
-                if fan_mode is not None and attributes.get(ATTR_FAN_MODE) != fan_mode:
-                    calls.append((DOMAIN, SERVICE_SET_FAN_MODE, {"fan_mode": fan_mode}))
+                fan_value = _to_int(payload.get("fan", payload.get("v")))
+                current_fan_value = self._current_climate_fan_value(attributes)
+                if fan_value != current_fan_value:
+                    fan_mode = _climate_fan_mode(
+                        fan_value,
+                        self._config,
+                        attributes.get(ATTR_FAN_MODES, []),
+                    )
+                    if fan_mode is not None and attributes.get(ATTR_FAN_MODE) != fan_mode:
+                        calls.append((DOMAIN, SERVICE_SET_FAN_MODE, {"fan_mode": fan_mode}))
 
             if "l2r" in payload or "u2d" in payload:
                 current_l2r, current_u2d = _climate_current_swing_axes(
                     self._config, attributes.get(ATTR_SWING_MODE)
                 )
-                swing_value = MSG_SEPARATOR.join(
-                    [
-                        str(
-                            _payload_swing_axis_value(payload["l2r"])
-                            if "l2r" in payload
-                            else current_l2r
-                        ),
-                        str(
-                            _payload_swing_axis_value(payload["u2d"])
-                            if "u2d" in payload
-                            else current_u2d
-                        ),
-                    ]
+                swing_value = (
+                    _payload_swing_axis_value(payload["l2r"])
+                    if "l2r" in payload
+                    else current_l2r,
+                    _payload_swing_axis_value(payload["u2d"])
+                    if "u2d" in payload
+                    else current_u2d,
                 )
                 swing_mode = _climate_config_value(
                     self._config,
@@ -576,6 +457,12 @@ class ControllableSync(Sync):
 
         return False
 
+    def _current_climate_fan_value(self, attributes: Mapping[str, Any]) -> int | None:
+        """Return the Bemfa fan numeric value we'd currently report."""
+        payload = self._generate_msg_payload()
+        fan = payload.get("fan")
+        return _to_int(fan) if fan is not None else None
+
     def _async_call_service(
         self, domain: str, service: str, data: dict[str, Any]
     ) -> None:
@@ -604,85 +491,6 @@ class ControllableSync(Sync):
                 )
         self._hass.async_create_task(_run())
 
-    def _msg_to_parts(
-        self, msg: Any, attributes: ReadOnlyDict[Mapping[str, Any]]
-    ) -> list[str | int]:
-        """Convert Bemfa MI JSON into the legacy resolver parts."""
-
-        if isinstance(msg, dict):
-            payload = msg
-        else:
-            try:
-                payload = json.loads(msg)
-            except (TypeError, ValueError):
-                return str(msg).split(MSG_SEPARATOR)
-
-        if not isinstance(payload, dict):
-            return [str(payload)]
-
-        suffix = self._get_topic_suffix()
-        on = MSG_ON if payload.get("on", True) else MSG_OFF
-        parts: list[str | int] = [on]
-
-        if suffix == TopicSuffix.LIGHT:
-            if "bri" in payload:
-                parts.append(_to_int(payload["bri"]))
-            if "tv" in payload:
-                parts.append(1000000 // max(_to_int(payload["tv"]), 1))
-            elif all(key in payload for key in ("r", "g", "b")):
-                parts.append(
-                    _to_int(payload["r"]) * 256 * 256
-                    + _to_int(payload["g"]) * 256
-                    + _to_int(payload["b"])
-                )
-        elif suffix in (TopicSuffix.FAN, TopicSuffix.COVER):
-            if "v" in payload:
-                parts.append(_to_int(payload["v"]))
-        elif suffix in (TopicSuffix.CLIMATE, TopicSuffix.THERMOSTAT):
-            if "mode" in payload:
-                parts.append(_to_int(payload["mode"]))
-            if "t" in payload:
-                while len(parts) < 2:
-                    parts.append("")
-                parts.append(_to_int(payload["t"]))
-            if "fan" in payload or "v" in payload:
-                while len(parts) < 3:
-                    parts.append("")
-                parts.append(_to_int(payload.get("fan", payload.get("v"))))
-            if "l2r" in payload or "u2d" in payload:
-                while len(parts) < 4:
-                    parts.append("")
-                l2r = _payload_swing_axis_value(payload.get("l2r", 0))
-                u2d = _payload_swing_axis_value(payload.get("u2d", 0))
-                parts.extend([l2r, u2d])
-        elif suffix == TopicSuffix.WATER_HEATER:
-            if "t" in payload:
-                parts.append(_to_int(payload["t"]))
-            if "mode" in payload:
-                while len(parts) < 2:
-                    parts.append("")
-                parts.append(str(payload["mode"]))
-        elif suffix == TopicSuffix.AIR_PURIFIER:
-            if "mode" in payload:
-                parts.append(str(payload["mode"]))
-
-        return parts
-
-    @abstractmethod
-    def _msg_resolvers(
-        self,
-    ) -> list[
-        (
-            int,
-            int,
-            Callable[
-                [list[str | int], ReadOnlyDict[Mapping[str, Any]]],
-                (str, str, dict[str, Any]),
-            ],
-        )
-    ]:
-        raise NotImplementedError
-
 
 def _to_int(value: Any) -> int:
     """Convert JSON scalar values to int for Bemfa payload fields."""
@@ -694,10 +502,6 @@ def _to_int(value: Any) -> int:
     if isinstance(value, float):
         return round(value)
     return int(str(value))
-
-
-def _swing_axis_payload_value(value: Any) -> int:
-    return 360 if _to_int(value) != 0 else 0
 
 
 def _payload_swing_axis_value(value: Any) -> int:
@@ -726,18 +530,9 @@ def _climate_current_swing_axes(
 
     for key, value in zip(CLIMATE_SWING_CONFIG_KEYS, CLIMATE_SWING_VALUES):
         if config.get(key) == current_swing_mode:
-            l2r, u2d = value.split(MSG_SEPARATOR)
-            return (_to_int(l2r), _to_int(u2d))
+            return value
 
     return (0, 0)
-
-
-def _coerce_msg_value(value: Any) -> str | int:
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str) and value.isdigit():
-        return int(value)
-    return value
 
 
 def _climate_supported_modes() -> list[Any]:

--- a/custom_components/bemfa_cloud/sync_binary_sensor.py
+++ b/custom_components/bemfa_cloud/sync_binary_sensor.py
@@ -4,7 +4,7 @@
 from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.components.binary_sensor import DOMAIN
-from .const import MSG_OFF, MSG_ON, TopicSuffix
+from .const import TopicSuffix
 from .sync import SYNC_TYPES, Sync
 
 
@@ -29,13 +29,6 @@ class BinarySensor(Sync):
 
     def get_watched_entity_ids(self) -> list[str]:
         return [self._entity_id]
-
-    def _generate_msg_parts(self) -> list[str]:
-        state = self._hass.states.get(self._entity_id)
-        if state is None:
-            return []
-
-        return ["", "", "", MSG_ON if state.state == STATE_ON else MSG_OFF]
 
     def _generate_msg_payload(self) -> dict[str, bool]:
         state = self._hass.states.get(self._entity_id)

--- a/custom_components/bemfa_cloud/sync_climate.py
+++ b/custom_components/bemfa_cloud/sync_climate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Final
 
 import logging
-from collections.abc import Mapping, Callable
+from collections.abc import Mapping
 import voluptuous as vol
 
 from homeassistant.components.climate import (
@@ -19,11 +19,6 @@ from homeassistant.components.climate import (
     FAN_LOW,
     FAN_MEDIUM,
     FAN_HIGH,
-    SERVICE_SET_FAN_MODE,
-    SERVICE_SET_HVAC_MODE,
-    SERVICE_SET_PRESET_MODE,
-    SERVICE_SET_TEMPERATURE,
-    SERVICE_SET_SWING_MODE,
     SWING_OFF,
     SWING_HORIZONTAL,
     SWING_VERTICAL,
@@ -32,21 +27,13 @@ from homeassistant.components.climate import (
     DOMAIN,
 )
 
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    SERVICE_TURN_OFF,
-    SERVICE_TURN_ON,
-)
+from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
 )
-from homeassistant.util.read_only_dict import ReadOnlyDict
 from .const import (
-    MSG_OFF,
-    MSG_ON,
-    MSG_SEPARATOR,
     OPTIONS_FAN_SPEED_0_VALUE,
     OPTIONS_FAN_SPEED_1_VALUE,
     OPTIONS_FAN_SPEED_2_VALUE,
@@ -65,10 +52,11 @@ from .const import (
 from .utils import has_key
 from .sync import (
     SYNC_TYPES,
+    CLIMATE_SWING_CONFIG_KEYS,
+    CLIMATE_SWING_VALUES,
     ControllableSync,
-    _climate_fan_mode,
-    _climate_hvac_mode,
-    _climate_preset_mode,
+    UNPUBLISHABLE_STATES,
+    _climate_current_swing_axes,
 )
 
 _LOGGING = logging.getLogger(__name__)
@@ -123,12 +111,7 @@ DETAILS_CFG = [
             OPTIONS_SWING_VERTICAL_VALUE,
             OPTIONS_SWING_BOTH_VALUE,
         ],
-        CFG_VALUES: [
-            MSG_SEPARATOR.join(["0", "0"]),
-            MSG_SEPARATOR.join(["1", "0"]),
-            MSG_SEPARATOR.join(["0", "1"]),
-            MSG_SEPARATOR.join(["1", "1"]),
-        ],
+        CFG_VALUES: [(0, 0), (1, 0), (0, 1), (1, 1)],
         CFG_SUGGESTED: [SWING_OFF, SWING_HORIZONTAL, SWING_VERTICAL, SWING_BOTH],
     },
 ]
@@ -136,7 +119,7 @@ DETAILS_CFG = [
 
 def _get_detail_value(
     attributes: dict[str, Any], sync_config: dict[str, str], detail_cfg: Any
-) -> str:
+) -> Any:
     if has_key(attributes, detail_cfg[ATTR_NAME]):
         current_value = attributes[detail_cfg[ATTR_NAME]]
         for i in range(len(detail_cfg[CFG_KEYS])):
@@ -160,8 +143,8 @@ def _get_detail_value(
 
 
 def _bemfa_climate_mode(
-    state: str, attributes: ReadOnlyDict[Mapping[str, Any]]
-) -> int | str:
+    state: str, attributes: Mapping[str, Any]
+) -> int | None:
     preset_mode = str(attributes.get(ATTR_PRESET_MODE, "")).lower()
     if preset_mode in ("sleep", "sleep_mode", "睡眠"):
         return 6
@@ -169,7 +152,7 @@ def _bemfa_climate_mode(
         return 7
     if state in SUPPORTED_HVAC_MODES:
         return SUPPORTED_HVAC_MODES.index(state) + 1
-    return ""
+    return None
 
 
 @SYNC_TYPES.register("climate")
@@ -193,9 +176,6 @@ class Climate(ControllableSync):
         syncs = []
         for state in hass.states.async_all(cls._supported_domain()):
             hvac_modes = state.attributes.get(ATTR_HVAC_MODES, [])
-            # Only treat as air-conditioner (005) when the entity supports COOL.
-            # Heat-only entities (e.g. floor heating / thermostat) fall through
-            # to the Thermostat subclass and be reported as 010.
             if HVACMode.COOL not in hvac_modes:
                 continue
             syncs.append(cls(hass, state.entity_id, state.name))
@@ -232,102 +212,36 @@ class Climate(ControllableSync):
                             ] = selector
         return schema
 
-    def _msg_generators(
-        self,
-    ) -> list[Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]]:
-        return [
-            lambda state, attributes: MSG_OFF if state == HVACMode.OFF else MSG_ON,
-            lambda state, attributes: _bemfa_climate_mode(state, attributes),
-            lambda state, attributes: round(attributes[ATTR_TEMPERATURE])
-            if has_key(attributes, ATTR_TEMPERATURE)
-            else "",
-            lambda state, attributes: _get_detail_value(
-                attributes, self._config, DETAILS_CFG[0]
-            ),
-            lambda state, attributes: _get_detail_value(
-                attributes, self._config, DETAILS_CFG[1]
-            ),
-        ]
+    def _generate_msg_payload(self) -> dict[str, Any]:
+        state = self._hass.states.get(self._entity_id)
+        if state is None or state.state in UNPUBLISHABLE_STATES:
+            return {}
 
-    def _msg_resolvers(
-        self,
-    ) -> list[
-        (
-            int,
-            int,
-            Callable[
-                [list[str | int], ReadOnlyDict[Mapping[str, Any]]],
-                (str, str, dict[str, Any]),
-            ],
-        )
-    ]:
-        return [
-            (
-                0,
-                2,
-                self._resolve_power_or_mode,
-            ),
-            (
-                2,
-                3,
-                lambda msg, attributes: (
-                    DOMAIN,
-                    SERVICE_SET_TEMPERATURE,
-                    {ATTR_TEMPERATURE: msg[0]},
-                ),
-            ),
-            (
-                3,
-                4,
-                self._resolve_fan_mode,
-            ),
-            (
-                4,
-                6,
-                lambda msg, attributes: (
-                    DOMAIN,
-                    SERVICE_SET_SWING_MODE,
-                    {
-                        ATTR_SWING_MODE: self._config[
-                            DETAILS_CFG[1][CFG_KEYS][
-                                DETAILS_CFG[1][CFG_VALUES].index(
-                                    MSG_SEPARATOR.join(map(str, msg))
-                                )
-                            ]
-                        ]
-                    },
-                ),
-            ),
-        ]
+        attributes = state.attributes
+        on = state.state != HVACMode.OFF
+        payload: dict[str, Any] = {"on": on}
 
-    def _resolve_power_or_mode(
-        self, msg: list[str | int], attributes: ReadOnlyDict[Mapping[str, Any]]
-    ) -> tuple[str, str, dict[str, Any]]:
-        if msg[0] == MSG_OFF:
-            return DOMAIN, SERVICE_TURN_OFF, {}
-        if len(msg) == 1:
-            return DOMAIN, SERVICE_TURN_ON, {}
+        if not on:
+            return payload
 
-        mode = int(msg[1])
-        if hvac_mode := _climate_hvac_mode(mode):
-            return DOMAIN, SERVICE_SET_HVAC_MODE, {ATTR_HVAC_MODE: hvac_mode}
-        if preset_mode := _climate_preset_mode(mode, attributes.get(ATTR_PRESET_MODES, [])):
-            return DOMAIN, SERVICE_SET_PRESET_MODE, {"preset_mode": preset_mode}
-        # Unknown mode value — just power on without changing mode to avoid re-triggering
-        # state sync loops caused by an unrecognised mode resetting the AC state.
-        return DOMAIN, SERVICE_TURN_ON, {}
+        mode = _bemfa_climate_mode(state.state, attributes)
+        if mode is not None:
+            payload["mode"] = mode
 
-    def _resolve_fan_mode(
-        self, msg: list[str | int], attributes: ReadOnlyDict[Mapping[str, Any]]
-    ) -> tuple[str, str, dict[str, Any]]:
-        fan_mode = _climate_fan_mode(
-            int(msg[0]),
-            self._config,
-            attributes.get(ATTR_FAN_MODES, []),
-        )
-        if fan_mode is None:
-            return DOMAIN, SERVICE_TURN_ON, {}
-        return DOMAIN, SERVICE_SET_FAN_MODE, {ATTR_FAN_MODE: fan_mode}
+        if has_key(attributes, ATTR_TEMPERATURE):
+            payload["t"] = round(attributes[ATTR_TEMPERATURE])
+
+        fan_value = _get_detail_value(attributes, self._config, DETAILS_CFG[0])
+        if fan_value is not None:
+            payload["fan"] = fan_value
+
+        swing_value = _get_detail_value(attributes, self._config, DETAILS_CFG[1])
+        if isinstance(swing_value, tuple) and len(swing_value) == 2:
+            l2r, u2d = swing_value
+            payload["l2r"] = 360 if l2r else 0
+            payload["u2d"] = 360 if u2d else 0
+
+        return payload
 
 
 @SYNC_TYPES.register("thermostat")
@@ -344,12 +258,6 @@ class Thermostat(Climate):
 
     @classmethod
     def collect_supported_syncs(cls, hass):
-        # Treat a climate entity as a thermostat / floor-heating device (010)
-        # whenever it does NOT support COOL. This covers both:
-        #   * heat-only devices (floor heating, radiator, wall thermostat)
-        #   * entities without any HVAC mode information
-        # Air-conditioners (which must support COOL) are handled by the
-        # Climate parent class and reported as 005.
         return [
             cls(hass, state.entity_id, state.name)
             for state in hass.states.async_all(cls._supported_domain())

--- a/custom_components/bemfa_cloud/sync_cover.py
+++ b/custom_components/bemfa_cloud/sync_cover.py
@@ -1,20 +1,13 @@
 """Support for bemfa service."""
 from __future__ import annotations
 
-from collections.abc import Mapping, Callable
 from typing import Any
-from homeassistant.components.cover import ATTR_CURRENT_POSITION, ATTR_POSITION, DOMAIN
+from homeassistant.components.cover import ATTR_CURRENT_POSITION, DOMAIN
 
-from homeassistant.const import (
-    SERVICE_CLOSE_COVER,
-    SERVICE_OPEN_COVER,
-    SERVICE_SET_COVER_POSITION,
-    SERVICE_STOP_COVER,
-)
-from homeassistant.util.read_only_dict import ReadOnlyDict
-from .const import MSG_OFF, MSG_ON, TopicSuffix
+from homeassistant.const import STATE_OPEN
+from .const import TopicSuffix
 from .utils import has_key
-from .sync import SYNC_TYPES, ControllableSync
+from .sync import SYNC_TYPES, ControllableSync, UNPUBLISHABLE_STATES
 
 
 @SYNC_TYPES.register("cover")
@@ -33,51 +26,18 @@ class Cover(ControllableSync):
     def _supported_domain() -> str:
         return DOMAIN
 
-    def _msg_generators(
-        self,
-    ) -> list[Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]]:
-        return [
-            lambda state, attributes: MSG_OFF
-            if has_key(attributes, ATTR_CURRENT_POSITION)
-            and attributes[ATTR_CURRENT_POSITION] == 0
-            or not has_key(attributes, ATTR_CURRENT_POSITION)
-            and state == "closed"
-            else MSG_ON,
-            lambda state, attributes: attributes[ATTR_CURRENT_POSITION]
-            if has_key(attributes, ATTR_CURRENT_POSITION)
-            else "",
-        ]
+    def _generate_msg_payload(self) -> dict[str, Any]:
+        state = self._hass.states.get(self._entity_id)
+        if state is None or state.state in UNPUBLISHABLE_STATES:
+            return {}
 
-    def _msg_resolvers(
-        self,
-    ) -> list[
-        (
-            int,
-            int,
-            Callable[
-                [list[str | int], ReadOnlyDict[Mapping[str, Any]]],
-                (str, str, dict[str, Any]),
-            ],
-        )
-    ]:
-        return [
-            (
-                0,
-                2,
-                lambda msg, attributes: (
-                    DOMAIN,
-                    SERVICE_SET_COVER_POSITION,
-                    {ATTR_POSITION: msg[1]},
-                )
-                if len(msg) > 1
-                else (
-                    DOMAIN,
-                    SERVICE_OPEN_COVER
-                    if msg[0] == MSG_ON
-                    else SERVICE_CLOSE_COVER
-                    if msg[0] == MSG_OFF
-                    else SERVICE_STOP_COVER,
-                    {},
-                ),
-            )
-        ]
+        attributes = state.attributes
+        if has_key(attributes, ATTR_CURRENT_POSITION):
+            on = attributes[ATTR_CURRENT_POSITION] != 0
+        else:
+            on = state.state != "closed"
+
+        payload: dict[str, Any] = {"on": on}
+        if has_key(attributes, ATTR_CURRENT_POSITION):
+            payload["v"] = attributes[ATTR_CURRENT_POSITION]
+        return payload

--- a/custom_components/bemfa_cloud/sync_fan.py
+++ b/custom_components/bemfa_cloud/sync_fan.py
@@ -1,21 +1,16 @@
 """Support for bemfa service."""
 from __future__ import annotations
 
-from collections.abc import Mapping, Callable
+from collections.abc import Mapping
 from typing import Any
 from homeassistant.components.fan import (
-    ATTR_OSCILLATING,
     ATTR_PERCENTAGE,
     ATTR_PERCENTAGE_STEP,
     ATTR_PRESET_MODE,
-    ATTR_PRESET_MODES,
     DOMAIN,
-    SERVICE_OSCILLATE,
-    SERVICE_SET_PERCENTAGE,
 )
-from homeassistant.const import ATTR_DEVICE_CLASS, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_ON
-from homeassistant.util.read_only_dict import ReadOnlyDict
-from .const import MSG_OFF, MSG_ON, TopicSuffix
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_ON
+from .const import TopicSuffix
 from .utils import has_key
 from .sync import SYNC_TYPES, ControllableSync, UNPUBLISHABLE_STATES
 
@@ -44,19 +39,6 @@ class Fan(ControllableSync):
             if state.attributes.get(ATTR_DEVICE_CLASS) != "air_purifier"
         ]
 
-    def _msg_generators(
-        self,
-    ) -> list[Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]]:
-        return [
-            lambda state, attributes: MSG_ON if state == STATE_ON else MSG_OFF,
-            lambda state, attributes: self._fan_speed_value(attributes) or "",
-            lambda state, attributes: 1
-            if has_key(attributes, ATTR_OSCILLATING) and attributes[ATTR_OSCILLATING]
-            else 0
-            if has_key(attributes, ATTR_OSCILLATING)
-            else "",
-        ]
-
     def _generate_msg_payload(self) -> dict[str, Any]:
         """Generate a Bemfa fan JSON message, keeping speed when turned off."""
         state = self._hass.states.get(self._entity_id)
@@ -69,7 +51,7 @@ class Fan(ControllableSync):
         return payload
 
     @staticmethod
-    def _fan_speed_value(attributes: ReadOnlyDict[Mapping[str, Any]]) -> int | None:
+    def _fan_speed_value(attributes: Mapping[str, Any]) -> int | None:
         """Return Bemfa fan speed value in the supported 1-5 range."""
         if not has_key(attributes, ATTR_PERCENTAGE) or not has_key(
             attributes, ATTR_PERCENTAGE_STEP
@@ -81,49 +63,6 @@ class Fan(ControllableSync):
             return None
 
         return min(max(round(attributes[ATTR_PERCENTAGE] / percentage_step), 1), 5)
-
-    def _msg_resolvers(
-        self,
-    ) -> list[
-        (
-            int,
-            int,
-            Callable[
-                [list[str | int], ReadOnlyDict[Mapping[str, Any]]],
-                (str, str, dict[str, Any]),
-            ],
-        )
-    ]:
-        return [
-            (
-                0,
-                2,
-                lambda msg, attributes: (
-                    DOMAIN,
-                    SERVICE_SET_PERCENTAGE,
-                    {
-                        ATTR_PERCENTAGE: min(
-                            max(msg[1], 1) * attributes[ATTR_PERCENTAGE_STEP], 100
-                        )
-                    },
-                )
-                if len(msg) > 1 and has_key(attributes, ATTR_PERCENTAGE_STEP)
-                else (
-                    DOMAIN,
-                    SERVICE_TURN_ON if msg[0] == MSG_ON else SERVICE_TURN_OFF,
-                    {},
-                ),
-            ),
-            (
-                2,
-                3,
-                lambda msg, attributes: (
-                    DOMAIN,
-                    SERVICE_OSCILLATE,
-                    {ATTR_OSCILLATING: msg[0] == 1},
-                ),
-            ),
-        ]
 
 
 @SYNC_TYPES.register("air_purifier")
@@ -146,16 +85,6 @@ class AirPurifier(Fan):
             if state.attributes.get(ATTR_DEVICE_CLASS) == "air_purifier"
         ]
 
-    def _msg_generators(
-        self,
-    ) -> list[Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]]:
-        return [
-            lambda state, attributes: MSG_ON if state == STATE_ON else MSG_OFF,
-            lambda state, attributes: attributes[ATTR_PRESET_MODE]
-            if has_key(attributes, ATTR_PRESET_MODE)
-            else "",
-        ]
-
     def _generate_msg_payload(self) -> dict[str, Any]:
         """Generate a Bemfa air purifier JSON message."""
         state = self._hass.states.get(self._entity_id)
@@ -166,19 +95,3 @@ class AirPurifier(Fan):
         if has_key(state.attributes, ATTR_PRESET_MODE):
             payload["mode"] = state.attributes[ATTR_PRESET_MODE]
         return payload
-
-    def _msg_resolvers(
-        self,
-    ) -> list[
-        (
-            int,
-            int,
-            Callable[
-                [list[str | int], ReadOnlyDict[Mapping[str, Any]]],
-                (str, str, dict[str, Any]),
-            ],
-        )
-    ]:
-        return [
-            *super()._msg_resolvers(),
-        ]

--- a/custom_components/bemfa_cloud/sync_light.py
+++ b/custom_components/bemfa_cloud/sync_light.py
@@ -1,22 +1,15 @@
 """Support for bemfa service."""
 from __future__ import annotations
 
-from collections.abc import Mapping, Callable
 from typing import Any
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_BRIGHTNESS_PCT,
     ATTR_COLOR_TEMP_KELVIN,
-    ATTR_MIN_COLOR_TEMP_KELVIN,
-    ATTR_MAX_COLOR_TEMP_KELVIN,
     ATTR_RGB_COLOR,
-    ATTR_SUPPORTED_COLOR_MODES,
     DOMAIN,
-    ColorMode,
 )
-from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_ON
-from homeassistant.util.read_only_dict import ReadOnlyDict
-from .const import MSG_OFF, MSG_ON, TopicSuffix
+from homeassistant.const import STATE_ON
+from .const import TopicSuffix
 from .utils import has_key
 from .sync import SYNC_TYPES, ControllableSync, UNPUBLISHABLE_STATES
 
@@ -43,7 +36,7 @@ class Light(ControllableSync):
             return {}
 
         attributes = state.attributes
-        payload: dict[str, Any] = {MSG_ON: state.state == STATE_ON}
+        payload: dict[str, Any] = {"on": state.state == STATE_ON}
         if has_key(attributes, ATTR_BRIGHTNESS):
             payload["bri"] = round(attributes[ATTR_BRIGHTNESS] / 2.55)
         if has_key(attributes, ATTR_COLOR_TEMP_KELVIN):
@@ -53,65 +46,3 @@ class Light(ControllableSync):
             payload["g"] = attributes[ATTR_RGB_COLOR][1]
             payload["b"] = attributes[ATTR_RGB_COLOR][2]
         return payload
-
-    def _msg_generators(
-        self,
-    ) -> list[Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]]:
-        return [
-            lambda state, attributes: MSG_ON if state == STATE_ON else MSG_OFF,
-            lambda state, attributes: round(attributes[ATTR_BRIGHTNESS] / 2.55)
-            if has_key(attributes, ATTR_BRIGHTNESS)
-            else "",
-            lambda state, attributes: 1000000 // attributes[ATTR_COLOR_TEMP_KELVIN]
-            if has_key(attributes, ATTR_COLOR_TEMP_KELVIN)
-            else attributes[ATTR_RGB_COLOR][0] * 256 * 256
-            + attributes[ATTR_RGB_COLOR][1] * 256
-            + attributes[ATTR_RGB_COLOR][2]
-            if has_key(attributes, ATTR_RGB_COLOR)
-            else "",
-        ]
-
-    def _msg_resolvers(
-        self,
-    ) -> list[
-        (
-            int,
-            int,
-            Callable[
-                [list[str | int], ReadOnlyDict[Mapping[str, Any]]],
-                (str, str, dict[str, Any]),
-            ],
-        )
-    ]:
-        return [
-            (
-                0,
-                3,
-                lambda msg, attributes: (
-                    DOMAIN,
-                    SERVICE_TURN_ON if msg[0] == MSG_ON else SERVICE_TURN_OFF,
-                    {
-                        ATTR_BRIGHTNESS_PCT: msg[1],
-                        ATTR_COLOR_TEMP_KELVIN: min(
-                            max(1000000 // msg[2], attributes[ATTR_MIN_COLOR_TEMP_KELVIN]),
-                            attributes[ATTR_MAX_COLOR_TEMP_KELVIN],
-                        ),
-                    }
-                    if len(msg) > 2
-                    and has_key(attributes, ATTR_SUPPORTED_COLOR_MODES)
-                    and ColorMode.COLOR_TEMP in attributes[ATTR_SUPPORTED_COLOR_MODES]
-                    else {
-                        ATTR_BRIGHTNESS_PCT: msg[1],
-                        ATTR_RGB_COLOR: [
-                            msg[2] // 256 // 256,
-                            msg[2] // 256 % 256,
-                            msg[2] % 256,
-                        ],
-                    }
-                    if len(msg) > 2
-                    else {ATTR_BRIGHTNESS_PCT: msg[1]}
-                    if len(msg) > 1
-                    else {},
-                ),
-            )
-        ]

--- a/custom_components/bemfa_cloud/sync_sensor.py
+++ b/custom_components/bemfa_cloud/sync_sensor.py
@@ -21,13 +21,6 @@ SENSOR_PAYLOAD_BY_DEVICE_CLASS = {
     SensorDeviceClass.PM25: "pm25",
     SensorDeviceClass.CO2: "co2",
 }
-SENSOR_MSG_INDEX_BY_PAYLOAD = {
-    "t": 1,
-    "h": 2,
-    "illuminance": 4,
-    "pm25": 5,
-    "co2": 6,
-}
 
 
 @SYNC_TYPES.register("sensor")
@@ -53,19 +46,6 @@ class Sensor(Sync):
 
     def get_watched_entity_ids(self) -> list[str]:
         return [self._entity_id]
-
-    def _generate_msg_parts(self) -> list[str]:
-        state = self._hass.states.get(self._entity_id)
-        if state is None or state.state in UNPUBLISHABLE_STATES:
-            return []
-
-        payload_name = self._payload_name(state.attributes)
-        if payload_name is None:
-            return []
-
-        msg = [""] * SENSOR_MSG_INDEX_BY_PAYLOAD[payload_name]
-        msg.append(state.state)
-        return msg
 
     def _generate_msg_payload(self) -> dict[str, Any]:
         state = self._hass.states.get(self._entity_id)

--- a/custom_components/bemfa_cloud/sync_switch.py
+++ b/custom_components/bemfa_cloud/sync_switch.py
@@ -1,7 +1,7 @@
 """Support for bemfa service."""
 from __future__ import annotations
 
-from collections.abc import Mapping, Callable
+from collections.abc import Mapping
 from typing import Any
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
@@ -52,9 +52,8 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN
-from homeassistant.util.read_only_dict import ReadOnlyDict
-from .const import MSG_OFF, MSG_ON, TopicSuffix
-from .sync import SYNC_TYPES, ControllableSync
+from .const import TopicSuffix
+from .sync import SYNC_TYPES, ControllableSync, UNPUBLISHABLE_STATES
 
 
 @SYNC_TYPES.register("switch")
@@ -93,42 +92,21 @@ class Switch(ControllableSync):
             syncs.append(cls(hass, state.entity_id, state.name))
         return syncs
 
-    def _msg_generators(
-        self,
-    ) -> list[Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]]:
-        return [self._msg_generator()]
+    def _generate_msg_payload(self) -> dict[str, Any]:
+        state = self._hass.states.get(self._entity_id)
+        if state is None or state.state in UNPUBLISHABLE_STATES:
+            return {}
+        return {"on": self._is_on(state.state, state.attributes)}
 
-    def _msg_resolvers(
-        self,
-    ) -> list[
-        (
-            int,
-            int,
-            Callable[
-                [list[str | int], ReadOnlyDict[Mapping[str, Any]]],
-                (str, str, dict[str, Any]),
-            ],
-        )
-    ]:
-        return [
-            (
-                # split bemfa msg by "#", then take a sub list
-                0,  # from this index
-                1,  # to this index
-                lambda msg, attributes: (  # and pass to this fun as param "msg"
-                    self._service_domain(),
-                    self._service_names()[0]
-                    if msg[0] == MSG_ON
-                    else self._service_names()[1],
-                    {},
-                ),
-            )
-        ]
+    def _is_on(self, state: str, attributes: Mapping[str, Any]) -> bool:
+        return state == STATE_ON
 
-    def _msg_generator(
-        self,
-    ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
-        return lambda state, attributes: MSG_ON if state == STATE_ON else MSG_OFF
+    def _resolve_on_off(
+        self, on: bool, attributes: Mapping[str, Any]
+    ) -> tuple[str, str, dict[str, Any]]:
+        domain = self._service_domain()
+        service = self._service_names()[0] if on else self._service_names()[1]
+        return (domain, service, {})
 
     def _service_domain(self) -> str:
         """Domain of service calls."""
@@ -147,10 +125,8 @@ class Camera(Switch):
     def _supported_domain() -> str:
         return CAMERA_DOMAIN
 
-    def _msg_generator(
-        self,
-    ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
-        return lambda state, attributes: MSG_OFF if state == _CAMERA_STATE_IDLE else MSG_ON
+    def _is_on(self, state: str, attributes: Mapping[str, Any]) -> bool:
+        return state != _CAMERA_STATE_IDLE
 
 
 @SYNC_TYPES.register("outlet")
@@ -190,10 +166,8 @@ class TV(Switch):
     def _supported_domain() -> str:
         return MEDIA_PLAYER_DOMAIN
 
-    def _msg_generator(
-        self,
-    ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
-        return lambda state, attributes: MSG_ON if state == STATE_PLAYING else MSG_OFF
+    def _is_on(self, state: str, attributes: Mapping[str, Any]) -> bool:
+        return state == STATE_PLAYING
 
     def resolve_msg(self, msg: Any):
         command = msg.get("action") if isinstance(msg, dict) else str(msg)
@@ -223,10 +197,8 @@ class Lock(Switch):
     def _supported_domain() -> str:
         return LOCK_DOMAIN
 
-    def _msg_generator(
-        self,
-    ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
-        return lambda state, attributes: MSG_OFF if state == 'locked' else MSG_ON
+    def _is_on(self, state: str, attributes: Mapping[str, Any]) -> bool:
+        return state != 'locked'
 
     def _service_names(self) -> tuple[str, str]:
         return (SERVICE_UNLOCK, SERVICE_LOCK)
@@ -240,10 +212,8 @@ class Scene(Switch):
     def _supported_domain() -> str:
         return SCENE_DOMAIN
 
-    def _msg_generator(
-        self,
-    ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
-        return lambda state, attributes: MSG_OFF
+    def _is_on(self, state: str, attributes: Mapping[str, Any]) -> bool:
+        return False
 
 
 @SYNC_TYPES.register("group")
@@ -266,47 +236,20 @@ class Vacuum(Switch):
     def _supported_domain() -> str:
         return VACUUM_DOMAIN
 
-    def _msg_generator(
-        self,
-    ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
-        return (
-            lambda state, attributes: MSG_ON
-            if state in [STATE_ON, _VACUUM_CLEANING]
-            else MSG_OFF
-        )
+    def _is_on(self, state: str, attributes: Mapping[str, Any]) -> bool:
+        return state in [STATE_ON, _VACUUM_CLEANING]
 
-    def _msg_resolvers(
-        self,
-    ) -> list[
-        (
-            int,
-            int,
-            Callable[
-                [list[str | int], ReadOnlyDict[Mapping[str, Any]]],
-                (str, str, dict[str, Any]),
-            ],
-        )
-    ]:
-        return [
-            (
-                0,
-                1,
-                lambda msg, attributes: (
-                    VACUUM_DOMAIN,
-                    SERVICE_START
-                    if msg[0] == MSG_ON
-                    and attributes[ATTR_SUPPORTED_FEATURES] & VacuumEntityFeature.START
-                    else SERVICE_TURN_ON
-                    if msg[0] == MSG_ON
-                    else SERVICE_RETURN_TO_BASE
-                    if msg[0] == MSG_OFF
-                    and attributes[ATTR_SUPPORTED_FEATURES]
-                    & VacuumEntityFeature.RETURN_HOME
-                    else SERVICE_STOP
-                    if msg[0] == MSG_OFF
-                    and attributes[ATTR_SUPPORTED_FEATURES] & VacuumEntityFeature.STOP
-                    else SERVICE_TURN_OFF,
-                    {},
-                ),
-            )
-        ]
+    def _resolve_on_off(
+        self, on: bool, attributes: Mapping[str, Any]
+    ) -> tuple[str, str, dict[str, Any]]:
+        features = attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        if on:
+            if features & VacuumEntityFeature.START:
+                return (VACUUM_DOMAIN, SERVICE_START, {})
+            return (VACUUM_DOMAIN, SERVICE_TURN_ON, {})
+        else:
+            if features & VacuumEntityFeature.RETURN_HOME:
+                return (VACUUM_DOMAIN, SERVICE_RETURN_TO_BASE, {})
+            if features & VacuumEntityFeature.STOP:
+                return (VACUUM_DOMAIN, SERVICE_STOP, {})
+            return (VACUUM_DOMAIN, SERVICE_TURN_OFF, {})

--- a/custom_components/bemfa_cloud/sync_water_heater.py
+++ b/custom_components/bemfa_cloud/sync_water_heater.py
@@ -1,7 +1,6 @@
 """Support for syncing Home Assistant water heaters to Bemfa Cloud."""
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
 from typing import Any
 
 from homeassistant.components.water_heater import (
@@ -10,10 +9,9 @@ from homeassistant.components.water_heater import (
     DOMAIN,
 )
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF
-from homeassistant.util.read_only_dict import ReadOnlyDict
 
-from .const import MSG_OFF, MSG_ON, TopicSuffix
-from .sync import SYNC_TYPES, ControllableSync
+from .const import TopicSuffix
+from .sync import SYNC_TYPES, ControllableSync, UNPUBLISHABLE_STATES
 from .utils import has_key
 
 
@@ -33,21 +31,19 @@ class WaterHeater(ControllableSync):
     def _supported_domain() -> str:
         return DOMAIN
 
-    def _msg_generators(
-        self,
-    ) -> list[Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]]:
-        return [
-            lambda state, attributes: MSG_OFF if state == STATE_OFF else MSG_ON,
-            lambda state, attributes: round(
+    def _generate_msg_payload(self) -> dict[str, Any]:
+        state = self._hass.states.get(self._entity_id)
+        if state is None or state.state in UNPUBLISHABLE_STATES:
+            return {}
+
+        attributes = state.attributes
+        payload: dict[str, Any] = {"on": state.state != STATE_OFF}
+        if has_key(attributes, ATTR_TEMPERATURE) or has_key(
+            attributes, ATTR_CURRENT_TEMPERATURE
+        ):
+            payload["t"] = round(
                 attributes.get(ATTR_TEMPERATURE, attributes.get(ATTR_CURRENT_TEMPERATURE))
             )
-            if has_key(attributes, ATTR_TEMPERATURE)
-            or has_key(attributes, ATTR_CURRENT_TEMPERATURE)
-            else "",
-            lambda state, attributes: attributes[ATTR_OPERATION_MODE]
-            if has_key(attributes, ATTR_OPERATION_MODE)
-            else "",
-        ]
-
-    def _msg_resolvers(self):
-        return []
+        if has_key(attributes, ATTR_OPERATION_MODE):
+            payload["mode"] = attributes[ATTR_OPERATION_MODE]
+        return payload


### PR DESCRIPTION
- Replace _msg_generators/_msg_resolvers/parts pipeline with direct _generate_msg_payload() returning JSON dict in each subclass
- Simplify resolve_msg() to call _resolve_json_msg() directly without parts fallback path
- Change CLIMATE_SWING_VALUES from "#" strings to tuples
- Remove MSG_SEPARATOR, MSG_ON, MSG_OFF from const.py
- Fix climate fan idempotency: compare received fan value against currently reported value to avoid ghost fan speed changes when Bemfa echoes back cached state during temperature adjustments
- Bump version to 0.1.13